### PR TITLE
Checkbox Kivu OS tests

### DIFF
--- a/checkbox-provider-kivu/units/os/category.pxu
+++ b/checkbox-provider-kivu/units/os/category.pxu
@@ -1,0 +1,4 @@
+unit: category
+id: kivu-os
+_name: Intel Kivu OS tests
+

--- a/checkbox-provider-kivu/units/os/jobs.pxu
+++ b/checkbox-provider-kivu/units/os/jobs.pxu
@@ -1,0 +1,8 @@
+plugin: shell
+category_id: kivu-os
+id: kivu-os/check-libva
+_summary: Check libva installation
+requires:
+  package.name == 'libva'
+flags: simple fail-on-resource
+command: echo "libva installed"

--- a/checkbox-provider-kivu/units/test-plan.pxu
+++ b/checkbox-provider-kivu/units/test-plan.pxu
@@ -8,3 +8,26 @@ mandatory_include:
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap
+
+id: kivu-os-full
+unit: test plan
+_name: Kivu (Full OS Tests)
+include:
+    kivu-os/.*
+nested_part:
+    graphics-integrated-gpu-cert-automated
+    cpu-cert-automated
+    audio-cert-automated
+    bluetooth-cert-automated
+    camera-cert-automated
+    input-cert-automated
+    keys-cert-automated
+    networking-cert-automated
+    usb-cert-automated
+    usb3-cert-automated
+    wireless-cert-automated
+mandatory_include:
+    com.canonical.certification::miscellanea/submission-resources
+bootstrap_include:
+    com.canonical.certification::executable
+    com.canonical.certification::snap


### PR DESCRIPTION
Add an other test plan for OS optimisation changes The OS test plan contains for the moment just 1 specific test (libva verification), it will be extended later on. It also include other standard tests from other providers on several components that are impacted by Kivu changes.