### PR TITLE
Fix zero copy test status check

### DIFF
--- a/checkbox-provider-kivu/units/webcam/jobs.pxu
+++ b/checkbox-provider-kivu/units/webcam/jobs.pxu
@@ -92,9 +92,10 @@ command:
       exit 1
   fi
   grep V4L2CaptureDelegateGpuHelper "${PLAINBOX_SESSION_SHARE}"/chromium_camera_stream_onecopy.log
-  if [[ $? -eq 1 ]] # No lines selected by grep?
+  ret_code=$?
+  if [[ "$ret_code" -ne 0 ]] # No lines selected by grep?
   then
-    echo "Failed: Could not detect use of V4L2CaptureDelegateGpuHelper"
+    echo "Failed: Could not detect use of V4L2CaptureDelegateGpuHelper or other errors ($ret_code)"
     exit 1
   fi
 _description:


### PR DESCRIPTION
We use grep to find a specific log on chrommium output Currently we declare test failed with grep returns 1, this will cause the test to be declared passed even if the log output is missing or in other circumstances. To make test more rubust, we rather declare the test failed if grep return code is not equal to 0