### PR TITLE
Add checkbox test for hardware overlay planes.

### DIFF
--- a/checkbox-provider-kivu/bin/active_dri_device.sh
+++ b/checkbox-provider-kivu/bin/active_dri_device.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# This script uses the gfxi tool to see which dri device is active.
+# This is useful when you have an iGPU and dGPU and want to know
+# which one is currently driving a screen.
+#
+# By bram.stolk@canonical.com
+
+crtc_card_0=`GFXI_DEVICE=/dev/dri/card0 gfxi crtc ACTIVE:1`
+if [ -n "$crtc_card_0" ]; then
+  echo /dev/dri/card0
+  exit 0
+fi
+
+crtc_card_1=`GFXI_DEVICE=/dev/dri/card1 gfxi crtc ACTIVE:1`
+if [ -n "$crtc_card_1" ]; then
+  echo /dev/dri/card1
+  exit 0
+fi
+
+crtc_card_2=`GFXI_DEVICE=/dev/dri/card2 gfxi crtc ACTIVE:1`
+if [ -n "$crtc_card_2" ]; then
+  echo /dev/dri/card2
+  exit 0
+fi
+
+exit 1
+

--- a/checkbox-provider-kivu/units/jobs.pxu
+++ b/checkbox-provider-kivu/units/jobs.pxu
@@ -349,3 +349,49 @@ depends:
 command:
   compare_intel_gpu_top_json.py --json "${PLAINBOX_SESSION_SHARE}"/chromium_h264_encoding_vaapi_enabled_intel_gpu_top.json "${PLAINBOX_SESSION_SHARE}"/chromium_h264_encoding_vaapi_disabled_intel_gpu_top.json
 
+id: kivu/hardware_overlay_mpv
+category_id: kivu
+plugin: shell
+user: root
+_summary: Play a video with mpv and check for hardware overlay use.
+depends:
+  kivu-common/prepare-test-data
+requires:
+  executable.name == "mpv"
+  executable.name == "gfxi"
+command:
+  export GFXI_DEVICE=`active_dri_device.sh`
+  if [ -z $GFXI_DEVICE ]
+  then
+    echo Could not find a dri device actively driving a screen.
+    exit 1
+  else
+    echo Using dri device: $GFXI_DEVICE
+  fi
+  # Play a video using mpv.
+  exec sudo --preserve-env -u "${NORMAL_USER}" timeout 10 mpv "${PLAINBOX_PROVIDER_DATA}"/bbb_h264_2160p_60fps_extract.mp4 &
+  sleep 3
+  # Check which CRTC is active at the moment.
+  # That is where we expect the overlay to show up.
+  CRTC=`gfxi crtc ACTIVE:1`
+  if [ -z "$CRTC" ]
+  then
+    echo Failed to get active CRTC for $GFXI_DEVICE
+    exit 1
+  fi
+  echo Using CRTC with id $CRTC from device $GFXI_DEVICE
+  # List the active planes on this crtc.
+  gfxi --annotate CRTC_ID:$CRTC ACTIVE:1 | tee "${PLAINBOX_SESSION_SHARE}"/mpv_planes.log
+  # See if the list has an entry with an overlay plane.
+  grep "Overlay" "${PLAINBOX_SESSION_SHARE}"/mpv_planes.log
+  ret_code=$?
+  if [[ "$ret_code" -ne 0 ]] # No lines selected by grep?
+  then
+    echo "No hardware overlay plane active or other errors ($ret_code)."
+    exit 1
+  else
+    echo Overlay plane usage detected.
+    cat "${PLAINBOX_SESSION_SHARE}"/mpv_planes.log
+    exit 0
+  fi
+

--- a/checkbox-provider-kivu/units/packaging.pxu
+++ b/checkbox-provider-kivu/units/packaging.pxu
@@ -5,3 +5,4 @@ Depends:
  gstreamer1.0-vaapi,
  gstreamer1.0-tools,
  vainfo,
+ mpv,


### PR DESCRIPTION
For now, uses mpv to play a video and uses gfxi to test if a hardware overlay plane is in use.
NOTE: This will currently fail on Mutter, but can succeed using Weston compositor.

Fixes: #20
KIVU-97