### PR TITLE
Made checkbox slave systemd service restart always

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,25 @@ grade: stable
 
 base: core22
 
+# Here are the available applications of the kivu checkbox provider snap
+# To run : snap run checkbox-kivu-classic.<app>
+#
+# checkbox-cli:
+#   - checkbox client, can be used to talk to the checkbox daemon
+# configure:
+#   - inject environment variable into checkbox snap environnement
+#     the variable initial list can be found in config/config_vars
+#     use configure -l to get the list of the current variables
+#     For example, a useful use case is to inject environment variable
+#     to enable debugging output (LIBVA_MESSAGING_LEVEL)
+# remote-slave:
+#   - checkbox slave daemon that will the responsible for running the test sesssion
+#     in the remote fashion (through checkbox-cli)
+# test-runner / test-runner-automated:
+#   - execute all provider tests inside the snap environment
+#     the test execution is standalone and does not depend on the remote-slave daemon
+# shell:
+#   - give shell access to the provider snap
 apps:
   checkbox-cli:
     command-chain: [bin/wrapper_local]
@@ -19,7 +38,7 @@ apps:
     command-chain: [bin/wrapper_local]
     command: bin/checkbox-cli-wrapper slave
     daemon: simple
-    restart-condition: on-failure
+    restart-condition: always
   shell:
     command-chain: [bin/wrapper_local]
     command: bin/shell-wrapper


### PR DESCRIPTION
When the test session is interrupted by user (ctrl-c), the checkbox slave exited with SUCCESS status and remains inactive. We want it to be always active in order to start new test session. The solution is to make the systemd service restart "always" and not only on failure