### PR TITLE
Fix test-runner and test-runner-automated script

### DIFF
--- a/launchers/checkbox-cli-wrapper
+++ b/launchers/checkbox-cli-wrapper
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-exec checkbox-cli "$@"
+# wrapper around the checkbox-cli
+# use absolute path in order to not use system checkbox-cli (from deb packages)
+exec /snap/checkbox22/current/bin/checkbox-cli "$@"


### PR DESCRIPTION
In case checkbox-cli is also available through deb packages enforce the use of checkbox22 checkbox-cli app to launch test session