### PR TITLE
Enhance screen saver management

### DIFF
--- a/checkbox-provider-kivu/units/common/jobs.pxu
+++ b/checkbox-provider-kivu/units/common/jobs.pxu
@@ -37,13 +37,16 @@ category_id: kivu-common
 flags: simple
 requires:
   executable.name == "dbus-send"
+  executable.name == "gsettings"
 _summary: Disable sreensaver (with GNOME)
 command:
-  # Note: this binary gets in the way:
-  # /snap/checkbox22/current/usr/bin/dbus-send
-  # So provide full path instead.
-  tool=/usr/bin/dbus-send
-  screen_saver_status=`$tool --session --print-reply=literal --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.GetActive`
+  # robust against reboot
+  /usr/bin/gsettings set org.gnome.desktop.lockdown disable-lock-screen 'true'
+  /usr/bin/gsettings set org.gnome.desktop.screensaver lock-enabled false
+  /usr/bin/gsettings set org.gnome.desktop.screensaver idle-activation-enabled false
+  # Disable screen-saver if it is currently enabled
+  # use system dbus-send with absolute path because /snap/checkbox22/current/usr/bin/dbus-send does not work
+  screen_saver_status=`/usr/bin/dbus-send --session --print-reply=literal --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.GetActive`
   if [[ $? -ne 0 ]]; then
     echo "The dbus-send command failed."
     exit $?

--- a/checkbox-provider-kivu/units/jobs.pxu
+++ b/checkbox-provider-kivu/units/jobs.pxu
@@ -55,6 +55,8 @@ id: kivu/gstreamer_h264_decoding_{{ driver }}
 category_id: kivu
 plugin: shell
 _summary: Decode H264 video with gstreamer and capture GPU usage
+depends:
+  kivu-common/prepare-test-data
 requires:
   executable.name == "gst-launch-1.0"
   {% if driver == "i915" %}
@@ -82,12 +84,12 @@ category_id: kivu
 flags: simple
 user: root
 _summary: Grab chrome://gpu url and inspect for HW compositor.
+depends:
+  kivu-common/prepare-test-data
 requires:
   executable.name == "ydotool"
   executable.name == "wl-paste"
   snap.name == "chromium"
-#depends:
-#  kivu-common/disable-screensaver
 environ:
   # necessary for local mode
   XDG_SESSION_TYPE
@@ -124,8 +126,8 @@ requires:
   executable.name == "ydotool"
   executable.name == "wl-paste"
   snap.name == "chromium"
-#depends:
-#  kivu-common/disable-screensaver
+depends:
+  kivu-common/prepare-test-data
 environ:
   # necessary for local mode
   XDG_SESSION_TYPE

--- a/checkbox-provider-kivu/units/power/jobs.pxu
+++ b/checkbox-provider-kivu/units/power/jobs.pxu
@@ -4,7 +4,7 @@ plugin: shell
 user: root
 _summary: Check power saving on a video playback with Chromum Hw Acc
 depends:
-  kivu-common/disable-screensaver
+  kivu-common/prepare-test-data
 requires:
   snap.name == "chromium"
 environ:


### PR DESCRIPTION
Add screensaver job as dependancy of test-prepare-data
Add test-prepare-data as dependancy of jobs that do not have it as dependancy yet 
Improve the screensaver job to disable it and be resilient even after reboot (using gsettings)

KIVU-130