### PR TITLE
Add test cleanup for screen saver disabling

### DIFF
--- a/checkbox-provider-kivu/units/common/jobs.pxu
+++ b/checkbox-provider-kivu/units/common/jobs.pxu
@@ -60,6 +60,10 @@ requires:
   executable.name == "gsettings"
 _summary: Disable sreensaver (with GNOME)
 command:
+  echo "Disabling screensaver settings"
+  /usr/bin/gsettings get org.gnome.desktop.lockdown disable-lock-screen > /tmp/orig_disable-lock
+  /usr/bin/gsettings get org.gnome.desktop.screensaver lock-enabled > /tmp/orig_lock-enabled
+  /usr/bin/gsettings get org.gnome.desktop.screensaver idle-activation-enabled > /tmp/orig_idle-activation
   # robust against reboot
   /usr/bin/gsettings set org.gnome.desktop.lockdown disable-lock-screen 'true'
   /usr/bin/gsettings set org.gnome.desktop.screensaver lock-enabled false
@@ -103,3 +107,19 @@ command:
   source export_va_path.sh
   va-support.py
 estimated_duration: 1s
+
+unit: job
+id: kivu-common/reset-screensaver
+category_id: kivu-common
+requires:
+  executable.name == "gsettings"
+_summary: Return screensaver settings back to what they were before disable-screensaver
+plugin: shell
+command:
+  /usr/bin/gsettings set org.gnome.desktop.lockdown disable-lock-screen $(cat /tmp/orig_disable-lock)
+  /usr/bin/gsettings set org.gnome.desktop.screensaver lock-enabled $(cat /tmp/orig_lock-enabled)
+  /usr/bin/gsettings set org.gnome.desktop.screensaver idle-activation-enabled $(cat /tmp/orig_idle-activation)
+  rm /tmp/orig_disable-lock
+  rm /tmp/orig_lock-enabled
+  rm /tmp/orig_idle-activation
+  echo "Cleaned up screensaver test settings"

--- a/checkbox-provider-kivu/units/jobs.pxu
+++ b/checkbox-provider-kivu/units/jobs.pxu
@@ -50,6 +50,7 @@ plugin: shell
 _summary: Decode H264 video with gstreamer and capture GPU usage
 depends:
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   executable.name == "gst-launch-1.0"
   {% if driver == "i915" %}
@@ -82,6 +83,7 @@ user: root
 _summary: Grab chrome://gpu url and inspect for HW compositor.
 depends:
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   executable.name == "ydotool"
   executable.name == "wl-paste"
@@ -126,6 +128,7 @@ requires:
   snap.name == "chromium"
 depends:
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 environ:
   # necessary for local mode
   XDG_SESSION_TYPE
@@ -181,6 +184,7 @@ user: root
 _summary: Play H264 video using Chromium (VAAPI enabled) and capture GPU usage
 depends:
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   snap.name == "chromium"
   {% if driver == "i915" %}
@@ -221,6 +225,7 @@ user: root
 _summary: Play H264 video using Chromium (VAAPI disabled) and capture GPU usage
 depends:
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   snap.name == "chromium"
   {% if driver == "i915" %}
@@ -257,6 +262,7 @@ user: root
 _summary: Play non-embedded H264 video using Chromium (VAAPI enabled)
 depends:
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   snap.name == "chromium"
 command:
@@ -300,6 +306,7 @@ user: root
 _summary: Encode H264 stream from within Chromium (VAAPI enabled) and capture GPU usage
 depends:
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   snap.name == "chromium"
   {% if driver == "i915" %}
@@ -344,6 +351,7 @@ user: root
 _summary: Encode H264 stream from within Chromium (VAAPI disabled) and capture GPU usage
 depends:
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   snap.name == "chromium"
   {% if driver == "i915" %}
@@ -504,6 +512,7 @@ user: root
 _summary: Play twenty H264 videos (VAAPI enabled) to check maxed out hw accel
 depends:
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   executable.name == "mpv"
 environ:
@@ -542,6 +551,7 @@ user: root
 _summary: Play twenty H264 videos in Chromium to check maxed out hw accel
 depends:
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   snap.name == "chromium"
   executable.name == "intel_gpu_top"

--- a/checkbox-provider-kivu/units/webcam/jobs.pxu
+++ b/checkbox-provider-kivu/units/webcam/jobs.pxu
@@ -45,6 +45,7 @@ _summary: Encode {{ Enc }} webcam video with chromium and capture GPU usage
 depends:
   camera/detect
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   snap.name == "chromium"
   graphics_card.driver == 'i915'
@@ -84,6 +85,7 @@ _summary: Encode H264 webcam video and check onecopy usage
 depends:
   camera/detect
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   snap.name == "chromium"
 command:
@@ -120,6 +122,7 @@ _summary: Check power usage gain by one copy
 depends:
   camera/detect
   kivu-common/prepare-test-data
+after: kivu-common/reset-screensaver
 requires:
   snap.name == "chromium"
 command:


### PR DESCRIPTION
We currently disable the screensaver and then do not clean up the device state after the test finishes. This patch stores the original values and resets them when the test is done by assigning a job with "after:"