### PR TITLE
Force some tests to use VA librairies from chromium

### DIFF
--- a/checkbox-provider-kivu/units/jobs.pxu
+++ b/checkbox-provider-kivu/units/jobs.pxu
@@ -20,6 +20,11 @@ requires:
 environ: GST_PLUGIN
 command:
   tdb.py reset
+  # We want the validate VA-API features of chromium, so use VA drivers from chromium, not the host
+  # For libva
+  export LD_LIBRARY_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  # For VA backend driver (iHD, radeonsi, ..)
+  export LIBVA_DRIVERS_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/dri/
   GPU_LOAD_CMD=$(which gpu-load.py)
   # NB : preserve PATH of user for the sudo (if not, intel_gpu_top will not be found)
   # --preserve-env can be used but it will not work because of the secure_path option 
@@ -59,6 +64,11 @@ requires:
 environ: GST_PLUGIN
 command:
   tdb.py reset
+  # We want the validate VA-API features of chromium, so use VA drivers from chromium, not the host
+  # For libva
+  export LD_LIBRARY_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  # For VA backend driver (iHD, radeonsi, ..)
+  export LIBVA_DRIVERS_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/dri/
   GPU_LOAD_CMD=$(which gpu-load.py)
   # NB : preserve PATH of user for the sudo (if not, intel_gpu_top will not be found)
   # --preserve-env can be used but it will not work because of the secure_path option 
@@ -512,6 +522,11 @@ environ:
   NORMAL_USER
 command:
   tdb.py reset
+  # We want the validate VA-API features of chromium, so use VA drivers from chromium, not the host
+  # For libva
+  export LD_LIBRARY_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  # For VA backend driver (iHD, radeonsi, ..)
+  export LIBVA_DRIVERS_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/dri/
   GPU_LOAD_CMD=$(which gpu-thresh.py)
   # Since it's a stress test, set the threshold near 100% video engine utilization
   echo "{\"gpu_usage_over_threshold_duration_{{ driver }}\": $(sudo ${GPU_LOAD_CMD} --timeout=30 --video_engine=Video --threshold=99.3 --gpu={{ driver }})}" | tdb.py insert &

--- a/checkbox-provider-kivu/units/webcam/jobs.pxu
+++ b/checkbox-provider-kivu/units/webcam/jobs.pxu
@@ -10,6 +10,11 @@ requires:
   package.name == "gstreamer1.0-vaapi"
 environ: GST_PLUGIN
 command:
+  # We want the validate VA-API features of chromium, so use VA drivers from chromium, not the host
+  # For libva
+  export LD_LIBRARY_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  # For VA backend driver (iHD, radeonsi, ..)
+  export LIBVA_DRIVERS_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/dri/
   timeout 10 intel_gpu_top -J > "${PLAINBOX_SESSION_SHARE}"/gstreamer_raw_webcam_encoding_intel_gpu_top.json &
   gpu_top_pid=$!
   timeout 10 gst-launch-1.0 -v --gst-plugin-path="${GST_PLUGIN}" v4l2src ! videoconvert ! video/x-raw ! fakesink


### PR DESCRIPTION
We want to test VA features of chromium so we should use librairies from chromium instead of host's ones (for test with gstreamer, mpv, etc ..)

KIVU-147