### PR TITLE
Adaptation of the tests after removal of chromium librairies

### DIFF
--- a/checkbox-provider-kivu/bin/detect-gnome.sh
+++ b/checkbox-provider-kivu/bin/detect-gnome.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+GNOME=$(snap connections chromium | grep -Po 'gnome(-\d+)+')
+if [ -z "GNOME" ]; then
+    exit 1
+fi
+
+# GNOME contains multiple instances of gnome-xx, take only the first one
+set -- $GNOME
+
+echo $1

--- a/checkbox-provider-kivu/bin/export_va_path.sh
+++ b/checkbox-provider-kivu/bin/export_va_path.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$0" = "$BASH_SOURCE" ]; then
+    echo "Error: Script must be sourced"
+    exit 1
+fi
+
+SCRIPT_PATH="$(dirname -- "${BASH_SOURCE[0]}")"
+
+# We want the validate VA-API features of chromium, so use VA drivers from chromium and gnome sdk
+# We do not want to use the host's librairies
+
+GNOME_SDK=$(${SCRIPT_PATH}/detect-gnome.sh)
+# libva
+export LD_LIBRARY_PATH=/snap/${GNOME_SDK}/current/usr/lib/x86_64-linux-gnu:/snap/chromium/current/usr/lib/x86_64-linux-gnu/
+# intel media driver backend
+export LIBVA_DRIVERS_PATH=/snap/${GNOME_SDK}/current/usr/lib/x86_64-linux-gnu/dri/

--- a/checkbox-provider-kivu/units/common/jobs.pxu
+++ b/checkbox-provider-kivu/units/common/jobs.pxu
@@ -12,8 +12,7 @@ plugin: attachment
 _summary: Attach content of vainfo
 requires: executable.name == "vainfo"
 command:
-  export LD_LIBRARY_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/
-  export LIBVA_DRIVERS_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/dri
+  source export_va_path.sh
   vainfo
 
 id: kivu-common/prepare-test-data
@@ -101,7 +100,6 @@ depends:
   kivu-common/vainfo
 plugin: resource
 command:
-  export LD_LIBRARY_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/
-  export LIBVA_DRIVERS_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/dri
+  source export_va_path.sh
   va-support.py
 estimated_duration: 1s

--- a/checkbox-provider-kivu/units/jobs.pxu
+++ b/checkbox-provider-kivu/units/jobs.pxu
@@ -20,11 +20,7 @@ requires:
 environ: GST_PLUGIN
 command:
   tdb.py reset
-  # We want the validate VA-API features of chromium, so use VA drivers from chromium, not the host
-  # For libva
-  export LD_LIBRARY_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-  # For VA backend driver (iHD, radeonsi, ..)
-  export LIBVA_DRIVERS_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/dri/
+  source export_va_path.sh
   GPU_LOAD_CMD=$(which gpu-load.py)
   # NB : preserve PATH of user for the sudo (if not, intel_gpu_top will not be found)
   # --preserve-env can be used but it will not work because of the secure_path option 
@@ -64,11 +60,7 @@ requires:
 environ: GST_PLUGIN
 command:
   tdb.py reset
-  # We want the validate VA-API features of chromium, so use VA drivers from chromium, not the host
-  # For libva
-  export LD_LIBRARY_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-  # For VA backend driver (iHD, radeonsi, ..)
-  export LIBVA_DRIVERS_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/dri/
+  source export_va_path.sh
   GPU_LOAD_CMD=$(which gpu-load.py)
   # NB : preserve PATH of user for the sudo (if not, intel_gpu_top will not be found)
   # --preserve-env can be used but it will not work because of the secure_path option 
@@ -522,11 +514,7 @@ environ:
   NORMAL_USER
 command:
   tdb.py reset
-  # We want the validate VA-API features of chromium, so use VA drivers from chromium, not the host
-  # For libva
-  export LD_LIBRARY_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-  # For VA backend driver (iHD, radeonsi, ..)
-  export LIBVA_DRIVERS_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/dri/
+  source export_va_path.sh
   GPU_LOAD_CMD=$(which gpu-thresh.py)
   # Since it's a stress test, set the threshold near 100% video engine utilization
   echo "{\"gpu_usage_over_threshold_duration_{{ driver }}\": $(sudo ${GPU_LOAD_CMD} --timeout=30 --video_engine=Video --threshold=99.3 --gpu={{ driver }})}" | tdb.py insert &

--- a/checkbox-provider-kivu/units/webcam/jobs.pxu
+++ b/checkbox-provider-kivu/units/webcam/jobs.pxu
@@ -10,11 +10,7 @@ requires:
   package.name == "gstreamer1.0-vaapi"
 environ: GST_PLUGIN
 command:
-  # We want the validate VA-API features of chromium, so use VA drivers from chromium, not the host
-  # For libva
-  export LD_LIBRARY_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-  # For VA backend driver (iHD, radeonsi, ..)
-  export LIBVA_DRIVERS_PATH=/snap/chromium/current/usr/lib/x86_64-linux-gnu/dri/
+  source export_va_path.sh
   timeout 10 intel_gpu_top -J > "${PLAINBOX_SESSION_SHARE}"/gstreamer_raw_webcam_encoding_intel_gpu_top.json &
   gpu_top_pid=$!
   timeout 10 gst-launch-1.0 -v --gst-plugin-path="${GST_PLUGIN}" v4l2src ! videoconvert ! video/x-raw ! fakesink


### PR DESCRIPTION
We dropped libva and intel media driver from chromium We use gnome's ones instead.
Some adjustments are necessary for the tests to continue to run successfully

KIVU-145