### PR TITLE
Restrict vp8/vp9 test on intel GPU

### DIFF
--- a/checkbox-provider-kivu/units/webcam/jobs.pxu
+++ b/checkbox-provider-kivu/units/webcam/jobs.pxu
@@ -47,6 +47,7 @@ depends:
   kivu-common/prepare-test-data
 requires:
   snap.name == "chromium"
+  graphics_card.driver == 'i915'
 command:
   timeout 10 intel_gpu_top -J > "${PLAINBOX_SESSION_SHARE}"/chromium_{{ Enc }}_webcam_encoding_disabled_intel_gpu_top.json &
   gpu_top_pid=$!


### PR DESCRIPTION
Checkbox allows only one resource to be used for a job definition It is not easy to generate jobs for a list of codecs and list of GPUs at the same time. The easy solution right now is only enable those tests for Intel GPUs because that is the main focus of this provider

KIVU-147