### PR TITLE
kivu-webcam/gstreamer_h264_webcam_encoding : fix test failing

### DIFF
--- a/checkbox-provider-kivu/units/jobs.pxu
+++ b/checkbox-provider-kivu/units/jobs.pxu
@@ -20,7 +20,6 @@ requires:
 environ: GST_PLUGIN
 command:
   tdb.py reset
-  source export_va_path.sh
   GPU_LOAD_CMD=$(which gpu-load.py)
   # NB : preserve PATH of user for the sudo (if not, intel_gpu_top will not be found)
   # --preserve-env can be used but it will not work because of the secure_path option 
@@ -61,7 +60,6 @@ requires:
 environ: GST_PLUGIN
 command:
   tdb.py reset
-  source export_va_path.sh
   GPU_LOAD_CMD=$(which gpu-load.py)
   # NB : preserve PATH of user for the sudo (if not, intel_gpu_top will not be found)
   # --preserve-env can be used but it will not work because of the secure_path option 

--- a/checkbox-provider-kivu/units/webcam/jobs.pxu
+++ b/checkbox-provider-kivu/units/webcam/jobs.pxu
@@ -10,7 +10,6 @@ requires:
   package.name == "gstreamer1.0-vaapi"
 environ: GST_PLUGIN
 command:
-  source export_va_path.sh
   timeout 10 intel_gpu_top -J > "${PLAINBOX_SESSION_SHARE}"/gstreamer_raw_webcam_encoding_intel_gpu_top.json &
   gpu_top_pid=$!
   timeout 10 gst-launch-1.0 -v --gst-plugin-path="${GST_PLUGIN}" v4l2src ! videoconvert ! video/x-raw ! fakesink


### PR DESCRIPTION
gnome and chromium moved to core24 (on edge) and the test fails with folowing error messages when the provider runs on 22.04:

07:59:58  gst-launch-1.0: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found ...

Fixes #75 

PEK-1077